### PR TITLE
[Day-5] UserController 웹 테스트 오류 수정 및 각 테스트 리팩토링

### DIFF
--- a/app/src/test/java/com/codesoom/assignment/product/presentation/ProductControllerMockTest.java
+++ b/app/src/test/java/com/codesoom/assignment/product/presentation/ProductControllerMockTest.java
@@ -8,7 +8,6 @@ import com.codesoom.assignment.product.domain.Product;
 import com.codesoom.assignment.product.presentation.dto.ProductData;
 import com.codesoom.assignment.session.application.AuthenticationService;
 import com.codesoom.assignment.session.application.exception.InvalidTokenException;
-import com.codesoom.assignment.support.ProductFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -32,7 +31,6 @@ import static com.codesoom.assignment.support.ProductFixture.PRODUCT_2;
 import static com.codesoom.assignment.support.ProductFixture.PRODUCT_INVALID_MAKER;
 import static com.codesoom.assignment.support.ProductFixture.PRODUCT_INVALID_NAME;
 import static com.codesoom.assignment.support.ProductFixture.PRODUCT_INVALID_PRICE;
-import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -42,7 +40,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest({ProductController.class, MockMvcCharacterEncodingCustomizer.class})
@@ -75,10 +72,11 @@ class ProductControllerMockTest {
         @Test
         @DisplayName("200 코드로 응답한다")
         void it_responses_200() throws Exception {
-            mockMvc.perform(
-                            get("/products")
-                    )
-                    .andExpect(status().isOk());
+            ResultActions perform = mockMvc.perform(
+                    get("/products")
+            );
+
+            perform.andExpect(status().isOk());
 
             verify(productService).getProducts();
         }
@@ -101,10 +99,11 @@ class ProductControllerMockTest {
             @Test
             @DisplayName("200 코드로 응답한다")
             void it_responses_200() throws Exception {
-                mockMvc.perform(
-                                get("/products/" + ID_MIN.value())
-                        )
-                        .andExpect(status().isOk());
+                ResultActions perform = mockMvc.perform(
+                        get("/products/" + ID_MIN.value())
+                );
+
+                perform.andExpect(status().isOk());
 
                 verify(productService).getProduct(ID_MIN.value());
             }
@@ -123,8 +122,11 @@ class ProductControllerMockTest {
             @Test
             @DisplayName("404 코드로 응답한다")
             void it_responses_404() throws Exception {
-                mockMvc.perform(get("/products/" + ID_MAX.value()))
-                        .andExpect(status().isNotFound());
+                ResultActions perform = mockMvc.perform(
+                        get("/products/" + ID_MAX.value())
+                );
+
+                perform.andExpect(status().isNotFound());
 
                 verify(productService).getProduct(ID_MAX.value());
             }
@@ -164,7 +166,6 @@ class ProductControllerMockTest {
                 );
 
                 perform.andExpect(status().isCreated());
-                PRODUCT_이름_메이커_가격_이미지주소_값_검증(perform, PRODUCT_1);
 
                 verify(productService).createProduct(any(ProductData.class));
             }
@@ -302,11 +303,10 @@ class ProductControllerMockTest {
                     ResultActions perform = 상품_수정_API_요청(
                             ID_MIN.value(),
                             VALID_TOKEN_1.인증_헤더값(),
-                            PRODUCT_1.등록_요청_데이터_생성()
+                            PRODUCT_1.수정_요청_데이터_생성()
                     );
 
                     perform.andExpect(status().isOk());
-                    PRODUCT_이름_메이커_가격_이미지주소_값_검증(perform, PRODUCT_1);
 
                     verify(productService).updateProduct(eq(ID_MIN.value()), any(ProductData.class));
                 }
@@ -546,14 +546,5 @@ class ProductControllerMockTest {
                 delete(REQUEST_PRODUCT_URL + "/" + productId)
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
         );
-    }
-
-    private void PRODUCT_이름_메이커_가격_이미지주소_값_검증(ResultActions perform,
-                                              ProductFixture productFixture) throws Exception {
-
-        perform.andExpect(content().string(containsString(productFixture.이름())))
-                .andExpect(content().string(containsString(productFixture.메이커())))
-                .andExpect(content().string(containsString(String.valueOf(productFixture.가격()))))
-                .andExpect(content().string(containsString(productFixture.이미지_URL())));
     }
 }

--- a/app/src/test/java/com/codesoom/assignment/user/presentation/UserControllerMockTest.java
+++ b/app/src/test/java/com/codesoom/assignment/user/presentation/UserControllerMockTest.java
@@ -33,7 +33,6 @@ import static com.codesoom.assignment.support.UserFixture.USER_1;
 import static com.codesoom.assignment.support.UserFixture.USER_INVALID_EMAIL;
 import static com.codesoom.assignment.support.UserFixture.USER_INVALID_NAME;
 import static com.codesoom.assignment.support.UserFixture.USER_INVALID_PASSWORD;
-import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -42,7 +41,6 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest({UserController.class, MockMvcCharacterEncodingCustomizer.class})
@@ -98,7 +96,6 @@ class UserControllerMockTest {
                 ResultActions perform = 회원_등록_API_요청(USER_1);
 
                 perform.andExpect(status().isCreated());
-                USER_이름_이메일_값_검증(perform, USER_1);
 
                 verify(userService).registerUser(any(UserRegistrationData.class));
             }
@@ -174,9 +171,6 @@ class UserControllerMockTest {
 
                 perform.andExpect(status().isUnauthorized());
 
-                // 아니 왜 해당 테스트를 단일로 실행하면 통과 되는데, 전체 실행을 하면 invoke가 됐다고 실패가 되지...?
-                // 해당 구문은 isAuthenticated()에서 실패돼서 컨트롤러로 못들어오는 로직이여야 하는데..
-                // 심지어 위에 status().isUnauthorized() 코드는 검증 성공으로 뜸.... (verfiy 구문 주석하면 테스트 올패스)
                 verify(userService, never()).updateUser(eq(ID_MIN.value()), any(UserModificationData.class));
             }
         }
@@ -196,9 +190,6 @@ class UserControllerMockTest {
 
                 perform.andExpect(status().isUnauthorized());
 
-                // 아니 왜 해당 테스트를 단일로 실행하면 통과 되는데, 전체 실행을 하면 invoke가 됐다고 실패가 되지...?
-                // 해당 구문은 isAuthenticated()에서 실패돼서 컨트롤러로 못들어오는 로직이여야 하는데..
-                // 심지어 위에 status().isUnauthorized() 코드는 검증 성공으로 뜸.... (verfiy 구문 주석하면 테스트 올패스)
                 verify(userService, never()).updateUser(eq(ID_MIN.value()), any(UserModificationData.class));
             }
         }
@@ -231,7 +222,6 @@ class UserControllerMockTest {
                         );
 
                         perform.andExpect(status().isOk());
-                        USER_이름_이메일_값_검증(perform, USER_1);
 
                         verify(userService).updateUser(eq(ID_MIN.value()), any(UserModificationData.class));
                     }
@@ -325,9 +315,6 @@ class UserControllerMockTest {
 
                 perform.andExpect(status().isUnauthorized());
 
-                // 아니 왜 해당 테스트를 단일로 실행하면 통과 되는데, 전체 실행을 하면 invoke가 됐다고 실패가 되지...?
-                // 해당 구문은 isAuthenticated()에서 실패돼서 컨트롤러로 못들어오는 로직이여야 하는데..
-                // 심지어 위에 status().isUnauthorized() 코드는 검증 성공으로 뜸.... (verfiy 구문 주석하면 테스트 올패스)
                 verify(userService, never()).deleteUser(ID_MIN.value());
             }
         }
@@ -346,9 +333,6 @@ class UserControllerMockTest {
 
                 perform.andExpect(status().isUnauthorized());
 
-                // 아니 왜 해당 테스트를 단일로 실행하면 통과 되는데, 전체 실행을 하면 invoke가 됐다고 실패가 되지...?
-                // 해당 구문은 isAuthenticated()에서 실패돼서 컨트롤러로 못들어오는 로직이여야 하는데..
-                // 심지어 위에 status().isUnauthorized() 코드는 검증 성공으로 뜸.... (verfiy 구문 주석하면 테스트 올패스)
                 verify(userService, never()).deleteUser(ID_MIN.value());
             }
         }
@@ -426,10 +410,5 @@ class UserControllerMockTest {
                 delete(REQUEST_USER_URL + "/" + userId)
                         .header(HttpHeaders.AUTHORIZATION, authHeader)
         );
-    }
-
-    private void USER_이름_이메일_값_검증(ResultActions perform, UserFixture userFixture) throws Exception {
-        perform.andExpect(content().string(containsString(userFixture.이름())));
-        perform.andExpect(content().string(containsString(userFixture.이메일())));
     }
 }

--- a/app/src/test/java/com/codesoom/assignment/user/presentation/UserControllerMockTest.java
+++ b/app/src/test/java/com/codesoom/assignment/user/presentation/UserControllerMockTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -61,6 +62,8 @@ class UserControllerMockTest {
 
     @BeforeEach
     void setUp() {
+        Mockito.clearInvocations(userService);
+
         given(authenticationService.parseToken(eq(VALID_TOKEN_1.토큰_값())))
                 .willReturn(VALID_TOKEN_1.아이디());
 


### PR DESCRIPTION
## 작업 개요
- UserController MockMvc 웹 테스트에서 `@Mockbean` 필드가 각 테스트마다 초기화되지 않는 문제를 수정합니다.
- 테스트 결과 값 검증 메서드를 리팩토링합니다.

## 작업 내용
- [x] UserController 웹 테스트에서 `@Mockbean` 필드가 각 테스트마다 초기화 되지 않는 문제 수정
- [x] 기존 Controller 테스트 결과 값 검증 간소화
   - 기존에는 각 필드별로 세세히 검증했지만, Controller 테스트의 목적은 반환 값 검증이 메인이 아님
   - 응답 상태 코드 검증 및 내부 메서드 호출 검증에 집중

## 관련 자료

> UserController 웹 테스트에서 `@Mockbean` 필드가 각 테스트마다 초기화 되지 않는 문제 수정

- 해당 오류에 관한 포스팅 글입니다. [(Mockito의 verify() 오류 | feat. @Mockbean fields are not reset for @Nested tests)](https://velog.io/@beomdrive/Mockito%EC%9D%98-verify-%EC%98%A4%EB%A5%98-%ED%95%B4%EA%B2%B0-feat.-Mockbean-fields-are-not-reset-for-Nested-tests)