### PR TITLE
[Day-6] 회원 정보 수정은 본인만 가능하도록 범위를 제한한다

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,6 +75,9 @@ dependencies {
     // Spring Developer Tools
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
+    // Spring AOP
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
     // Spring Boot Test
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/app/src/main/java/com/codesoom/assignment/common/authentication/security/UserAuthentication.java
+++ b/app/src/main/java/com/codesoom/assignment/common/authentication/security/UserAuthentication.java
@@ -15,6 +15,10 @@ public class UserAuthentication extends AbstractAuthenticationToken {
         this.userId = userId;
     }
 
+    public Long getUserId() {
+        return userId;
+    }
+
     @Override
     public Object getCredentials() {
         return null;

--- a/app/src/main/java/com/codesoom/assignment/common/authorization/IdVerification.java
+++ b/app/src/main/java/com/codesoom/assignment/common/authorization/IdVerification.java
@@ -1,0 +1,14 @@
+package com.codesoom.assignment.common.authorization;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Access Token의 id와 요청 데이터의 PathVariable의 id를 비교해야 할 때 사용됩니다.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IdVerification {
+}

--- a/app/src/main/java/com/codesoom/assignment/common/authorization/UserAuthorizationAop.java
+++ b/app/src/main/java/com/codesoom/assignment/common/authorization/UserAuthorizationAop.java
@@ -1,0 +1,59 @@
+package com.codesoom.assignment.common.authorization;
+
+import com.codesoom.assignment.common.authentication.security.UserAuthentication;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.AccessDeniedException;
+import java.util.Arrays;
+
+@Aspect
+@Component
+public class UserAuthorizationAop {
+    /**
+     * `@IdVerification`이 선언된 메서드가 호출될 때 AOP가 적용됩니다.
+     */
+    @Pointcut("@annotation(com.codesoom.assignment.common.authorization.IdVerification)")
+    private void idVerificationMethod() {
+    }
+
+    /**
+     * Access Token을 통해 전달되는 id와 @PathVariable을 통해 전달되는 id를 서로 비교합니다.
+     *
+     * @param joinPoint 메서드 관련 정보
+     * @throws AccessDeniedException id가 존재하지 않거나 서로 다를 때 던집니다.
+     */
+    @Before("idVerificationMethod()")
+    private void validateId(final JoinPoint joinPoint) throws AccessDeniedException {
+        Long requestId = getIdByPathVariable(joinPoint);
+        Long tokenId = getIdByUserAuthentication(joinPoint);
+
+        if (!requestId.equals(tokenId)) {
+            throw new AccessDeniedException("");
+        }
+    }
+
+
+    // TODO: Controller 매개변수에 Long 타입이 두개 이상일 경우를 고려해야함
+    //       @PathVariable 값을 가져오는 방법으로 수정하기
+    private static Long getIdByPathVariable(final JoinPoint joinPoint) throws AccessDeniedException {
+        return Arrays.stream(joinPoint.getArgs())
+                .filter(Long.class::isInstance)
+                .map(Long.class::cast)
+                .findFirst()
+                .orElseThrow(() -> new AccessDeniedException(""));
+    }
+
+    private static Long getIdByUserAuthentication(final JoinPoint joinPoint) throws AccessDeniedException {
+        UserAuthentication userAuthentication = Arrays.stream(joinPoint.getArgs())
+                .filter(UserAuthentication.class::isInstance)
+                .map(UserAuthentication.class::cast)
+                .findFirst()
+                .orElseThrow(() -> new AccessDeniedException(""));
+
+        return userAuthentication.getUserId();
+    }
+}

--- a/app/src/main/java/com/codesoom/assignment/common/exception/ControllerErrorAdvice.java
+++ b/app/src/main/java/com/codesoom/assignment/common/exception/ControllerErrorAdvice.java
@@ -6,17 +6,16 @@ import com.codesoom.assignment.session.application.exception.LoginFailException;
 import com.codesoom.assignment.user.application.exception.UserEmailDuplicationException;
 import com.codesoom.assignment.user.application.exception.UserNotFoundException;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
+import java.nio.file.AccessDeniedException;
 import java.util.Set;
 
-@ResponseBody
-@ControllerAdvice
+@RestControllerAdvice
 public class ControllerErrorAdvice {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     @ExceptionHandler(ProductNotFoundException.class)
@@ -48,15 +47,19 @@ public class ControllerErrorAdvice {
         return new ErrorResponse("Invalid access token");
     }
 
-    @ResponseBody
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    @ExceptionHandler(AccessDeniedException.class)
+    public ErrorResponse handleAccessDeniedException() {
+        return new ErrorResponse("Access denied");
+    }
+
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(ConstraintViolationException.class)
-    public ErrorResponse handleConstraintValidateError(
-            ConstraintViolationException exception
-    ) {
+    public ErrorResponse handleConstraintValidateError(ConstraintViolationException exception) {
         String messageTemplate = getViolatedMessage(exception);
         return new ErrorResponse(messageTemplate);
     }
+
 
     private String getViolatedMessage(ConstraintViolationException exception) {
         String messageTemplate = null;

--- a/app/src/main/java/com/codesoom/assignment/common/utils/JwtUtil.java
+++ b/app/src/main/java/com/codesoom/assignment/common/utils/JwtUtil.java
@@ -20,7 +20,7 @@ public class JwtUtil {
 
     public String encode(final Long userId) {
         return Jwts.builder()
-                .claim("userId", 1L)
+                .claim("userId", userId)
                 .signWith(key)
                 .compact();
     }

--- a/app/src/main/java/com/codesoom/assignment/user/presentation/UserController.java
+++ b/app/src/main/java/com/codesoom/assignment/user/presentation/UserController.java
@@ -1,5 +1,7 @@
 package com.codesoom.assignment.user.presentation;
 
+import com.codesoom.assignment.common.authentication.security.UserAuthentication;
+import com.codesoom.assignment.common.authorization.IdVerification;
 import com.codesoom.assignment.user.application.UserService;
 import com.codesoom.assignment.user.domain.User;
 import com.codesoom.assignment.user.presentation.dto.UserModificationData;
@@ -39,9 +41,10 @@ public class UserController {
 
     @PatchMapping("{id}")
     @PreAuthorize("isAuthenticated()")
+    @IdVerification
     UserResultData update(@PathVariable final Long id,
                           @RequestBody @Valid final UserModificationData modificationData,
-                          final Authentication authentication) {
+                          final UserAuthentication userAuthentication) {
         User user = userService.updateUser(id, modificationData);
         return getUserResultData(user);
     }

--- a/app/src/test/java/com/codesoom/assignment/support/AuthHeaderFixture.java
+++ b/app/src/test/java/com/codesoom/assignment/support/AuthHeaderFixture.java
@@ -8,6 +8,13 @@ public enum AuthHeaderFixture {
             "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjF9.neCsyNLzy3lQ4o2yliotWT06FwSGZagaHpKdAkjnGGw",
             "Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjF9.neCsyNLzy3lQ4o2yliotWT06FwSGZagaHpKdAkjnGGw"
     ),
+    VALID_TOKEN_2(
+            "Bearer",
+            "12345678901234567890123456789010",
+            2L,
+            "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjJ9.i-iHszAs6H2JFTdm3vOVuN18tb_w6n2FqEYIRtr6gaU",
+            "Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjJ9.i-iHszAs6H2JFTdm3vOVuN18tb_w6n2FqEYIRtr6gaU"
+    ),
     INVALID_TYPE_TOKEN_1(
             "Gibeom",
             "12345678901234567890123456789010",

--- a/app/src/test/java/com/codesoom/assignment/support/IdFixture.java
+++ b/app/src/test/java/com/codesoom/assignment/support/IdFixture.java
@@ -2,6 +2,7 @@ package com.codesoom.assignment.support;
 
 public enum IdFixture {
     ID_MIN(1L),
+    ID_2(2L),
     ID_MAX(Long.MAX_VALUE),
     ;
 


### PR DESCRIPTION
## 개요
- 회원 데이터 수정은 본인 정보만 수정할 수 있다.

## 작업 요약
- 수정 시 인증 토큰의 userId와 요청 데이터의 userId를 비교하여 다를 경우 요청을 거절한다.
- AOP를 사용하여 userId를 비교 검증한다.

## 작업 내용
- [x] JwtUtil 토큰 encode 오류 수정
- [x] 회원 정보를 본인 정보만 수정할 수 있도록 제한
