### PR TITLE
[Day-7] 회원 역할 생성 후 회원 삭제는 관리자만 가능하도록 범위를 제한한다

### DIFF
--- a/app/src/main/java/com/codesoom/assignment/common/authentication/config/SecurityConfig.java
+++ b/app/src/main/java/com/codesoom/assignment/common/authentication/config/SecurityConfig.java
@@ -30,6 +30,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
         http
                 .csrf().disable()
+                .headers()
+                    .frameOptions().disable() // h2-console
+                .and()
                 .addFilterBefore(authenticationErrorFilter, JwtAuthenticationFilter.class)
                 .addFilter(authenticationFilter)
                 .sessionManagement()

--- a/app/src/main/java/com/codesoom/assignment/common/authentication/filters/JwtAuthenticationFilter.java
+++ b/app/src/main/java/com/codesoom/assignment/common/authentication/filters/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.codesoom.assignment.common.authentication.filters;
 
 import com.codesoom.assignment.common.authentication.security.UserAuthentication;
 import com.codesoom.assignment.session.application.AuthenticationService;
+import com.codesoom.assignment.session.domain.Role;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
@@ -14,6 +15,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
 
 public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
     private final AuthenticationService authenticationService;
@@ -32,14 +34,15 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
 
         if (authorization != null) {
             Long userId = getUserIdByAccessToken(authorization);
-            setAuthentication(userId);
+            List<Role> roles = authenticationService.roles(userId);
+            setAuthentication(userId, roles);
         }
 
         chain.doFilter(request, response);
     }
 
-    private static void setAuthentication(Long userId) {
-        Authentication authentication = new UserAuthentication(userId);
+    private static void setAuthentication(Long userId, List<Role> roles) {
+        Authentication authentication = new UserAuthentication(userId, roles);
 
         SecurityContext context = SecurityContextHolder.getContext();
         context.setAuthentication(authentication);

--- a/app/src/main/java/com/codesoom/assignment/common/authentication/security/UserAuthentication.java
+++ b/app/src/main/java/com/codesoom/assignment/common/authentication/security/UserAuthentication.java
@@ -1,17 +1,18 @@
 package com.codesoom.assignment.common.authentication.security;
 
+import com.codesoom.assignment.session.domain.Role;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class UserAuthentication extends AbstractAuthenticationToken {
     private final Long userId;
 
-    public UserAuthentication(Long userId) {
-        super(authorities());
+    public UserAuthentication(Long userId, List<Role> roles) {
+        super(authorities(roles));
         this.userId = userId;
     }
 
@@ -34,10 +35,9 @@ public class UserAuthentication extends AbstractAuthenticationToken {
         return true;
     }
 
-    private static List<GrantedAuthority> authorities() {
-        List<GrantedAuthority> authorities = new ArrayList<>();
-        // TODO: userId에 따라서 다른 권한 부여
-        authorities.add(new SimpleGrantedAuthority("USER"));
-        return authorities;
+    private static List<GrantedAuthority> authorities(List<Role> roles) {
+        return roles.stream()
+                .map(role -> new SimpleGrantedAuthority(role.getName()))
+                .collect(Collectors.toList());
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/session/application/AuthenticationService.java
+++ b/app/src/main/java/com/codesoom/assignment/session/application/AuthenticationService.java
@@ -2,19 +2,26 @@ package com.codesoom.assignment.session.application;
 
 import com.codesoom.assignment.common.utils.JwtUtil;
 import com.codesoom.assignment.session.application.exception.LoginFailException;
+import com.codesoom.assignment.session.domain.Role;
+import com.codesoom.assignment.session.domain.RoleRepository;
 import com.codesoom.assignment.user.domain.User;
 import com.codesoom.assignment.user.domain.UserRepository;
 import io.jsonwebtoken.Claims;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public class AuthenticationService {
     private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
     private final JwtUtil jwtUtil;
 
     public AuthenticationService(final UserRepository userRepository,
+                                 final RoleRepository roleRepository,
                                  final JwtUtil jwtUtil) {
         this.userRepository = userRepository;
+        this.roleRepository = roleRepository;
         this.jwtUtil = jwtUtil;
     }
 
@@ -33,5 +40,9 @@ public class AuthenticationService {
     public Long parseToken(final String accessToken) {
         Claims claims = jwtUtil.decode(accessToken);
         return claims.get("userId", Long.class);
+    }
+
+    public List<Role> roles(Long userId) {
+        return roleRepository.findAllByUserId(userId);
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/session/domain/Role.java
+++ b/app/src/main/java/com/codesoom/assignment/session/domain/Role.java
@@ -1,0 +1,29 @@
+package com.codesoom.assignment.session.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+@NoArgsConstructor
+public class Role {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private Long userId;
+    @Getter
+    private String name;
+
+    public Role(Long userId, String name) {
+        this.userId = userId;
+        this.name = name;
+    }
+
+    public Role(String name) {
+        this(null, name);
+    }
+}

--- a/app/src/main/java/com/codesoom/assignment/session/domain/RoleRepository.java
+++ b/app/src/main/java/com/codesoom/assignment/session/domain/RoleRepository.java
@@ -1,0 +1,9 @@
+package com.codesoom.assignment.session.domain;
+
+import java.util.List;
+
+public interface RoleRepository {
+    List<Role> findAllByUserId(Long userId);
+
+    Role save(Role role);
+}

--- a/app/src/main/java/com/codesoom/assignment/session/infra/JpaRoleRepository.java
+++ b/app/src/main/java/com/codesoom/assignment/session/infra/JpaRoleRepository.java
@@ -1,0 +1,13 @@
+package com.codesoom.assignment.session.infra;
+
+import com.codesoom.assignment.session.domain.Role;
+import com.codesoom.assignment.session.domain.RoleRepository;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+
+public interface JpaRoleRepository
+        extends RoleRepository, CrudRepository<Role, Long> {
+    List<Role> findAllByUserId(Long userId);
+    Role save(Role role);
+}

--- a/app/src/main/java/com/codesoom/assignment/user/application/UserService.java
+++ b/app/src/main/java/com/codesoom/assignment/user/application/UserService.java
@@ -1,5 +1,7 @@
 package com.codesoom.assignment.user.application;
 
+import com.codesoom.assignment.session.domain.Role;
+import com.codesoom.assignment.session.domain.RoleRepository;
 import com.codesoom.assignment.user.application.exception.UserEmailDuplicationException;
 import com.codesoom.assignment.user.application.exception.UserNotFoundException;
 import com.codesoom.assignment.user.domain.User;
@@ -16,10 +18,14 @@ import javax.transaction.Transactional;
 public class UserService {
     private final Mapper mapper;
     private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
 
-    public UserService(final Mapper dozerMapper, final UserRepository userRepository) {
+    public UserService(final Mapper dozerMapper,
+                       final UserRepository userRepository,
+                       RoleRepository roleRepository) {
         this.mapper = dozerMapper;
         this.userRepository = userRepository;
+        this.roleRepository = roleRepository;
     }
 
     public User registerUser(final UserRegistrationData registrationData) {
@@ -29,8 +35,15 @@ public class UserService {
             throw new UserEmailDuplicationException(email);
         }
 
-        User user = mapper.map(registrationData, User.class);
-        return userRepository.save(user);
+        User user = userRepository.save(
+                mapper.map(registrationData, User.class)
+        );
+
+        roleRepository.save(
+                new Role(user.getId(), "USER")
+        );
+
+        return user;
     }
 
     public User updateUser(final Long id,

--- a/app/src/main/java/com/codesoom/assignment/user/presentation/UserController.java
+++ b/app/src/main/java/com/codesoom/assignment/user/presentation/UserController.java
@@ -40,7 +40,7 @@ public class UserController {
     }
 
     @PatchMapping("{id}")
-    @PreAuthorize("isAuthenticated()")
+    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
     @IdVerification
     UserResultData update(@PathVariable final Long id,
                           @RequestBody @Valid final UserModificationData modificationData,
@@ -51,7 +51,7 @@ public class UserController {
 
     @DeleteMapping("{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @PreAuthorize("isAuthenticated() and (hasAuthority('USER') or hasAuthority('ADMIN'))")
+    @PreAuthorize("isAuthenticated() and hasAuthority('ADMIN')")
     void destroy(@PathVariable final Long id,
                  final Authentication authentication) {
         userService.deleteUser(id);

--- a/app/src/test/java/com/codesoom/assignment/support/AuthHeaderFixture.java
+++ b/app/src/test/java/com/codesoom/assignment/support/AuthHeaderFixture.java
@@ -15,6 +15,13 @@ public enum AuthHeaderFixture {
             "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjJ9.i-iHszAs6H2JFTdm3vOVuN18tb_w6n2FqEYIRtr6gaU",
             "Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjJ9.i-iHszAs6H2JFTdm3vOVuN18tb_w6n2FqEYIRtr6gaU"
     ),
+    VALID_ADMIN_TOKEN_1004(
+            "Bearer",
+            "12345678901234567890123456789010",
+            1004L,
+            "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjEwMDR9.iWkN84MBJ12T5IN0ZR_UVrPdfrh6cZP6R2McdZpW8zk",
+            "Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjEwMDR9.iWkN84MBJ12T5IN0ZR_UVrPdfrh6cZP6R2McdZpW8zk"
+    ),
     INVALID_TYPE_TOKEN_1(
             "Gibeom",
             "12345678901234567890123456789010",

--- a/app/src/test/java/com/codesoom/assignment/support/IdFixture.java
+++ b/app/src/test/java/com/codesoom/assignment/support/IdFixture.java
@@ -3,6 +3,7 @@ package com.codesoom.assignment.support;
 public enum IdFixture {
     ID_MIN(1L),
     ID_2(2L),
+    ID_1004(1004L),
     ID_MAX(Long.MAX_VALUE),
     ;
 

--- a/app/src/test/java/com/codesoom/assignment/user/application/UserServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/user/application/UserServiceTest.java
@@ -1,5 +1,7 @@
 package com.codesoom.assignment.user.application;
 
+import com.codesoom.assignment.session.domain.Role;
+import com.codesoom.assignment.session.domain.RoleRepository;
 import com.codesoom.assignment.support.UserFixture;
 import com.codesoom.assignment.user.application.exception.UserEmailDuplicationException;
 import com.codesoom.assignment.user.application.exception.UserNotFoundException;
@@ -33,13 +35,13 @@ class UserServiceTest {
     private static final Long DELETED_USER_ID = 200L;
 
     private UserService userService;
-
     private final UserRepository userRepository = mock(UserRepository.class);
+    private final RoleRepository roleRepository = mock(RoleRepository.class);
 
     @BeforeEach
     void setUp() {
         Mapper mapper = DozerBeanMapperBuilder.buildDefault();
-        userService = new UserService(mapper, userRepository);
+        userService = new UserService(mapper, userRepository, roleRepository);
     }
 
     @Nested
@@ -78,6 +80,7 @@ class UserServiceTest {
 
                 verify(userRepository).existsByEmail(USER_1.이메일());
                 verify(userRepository).save(USER_1.회원_엔티티_생성());
+                verify(roleRepository).save(any(Role.class));
             }
         }
 


### PR DESCRIPTION
## 개요
- 회원의 역할(Role)을 생성한다.
- 회원 데이터 삭제는 본인 및 관리자만 가능하다.

## 작업 요약
- 회원 역할을 USER, ADMIN으로 생성합니다.
- 회원 정보 삭제는 관리자만 삭제할 수 있도록 제한합니다

## 작업 내용
(체크 박스를 모두 선택해야 merge가 활성화 됩니다.)
- [x] 회원 역할 생성
- [x] 회원 정보 삭제는 관리자만 하도록 제한
